### PR TITLE
fix: make CI workflow reusable by adding workflow_call trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main, develop ]
   pull_request:
     branches: [ main ]
+  workflow_call:
 
 jobs:
   lint-and-typecheck:


### PR DESCRIPTION
The release workflow was failing because it tried to call ci.yml as a reusable workflow, but ci.yml didn't have the workflow_call trigger. Added workflow_call to allow the workflow to be called from other workflows.

🤖 Generated with [Claude Code](https://claude.ai/code)