### PR TITLE
Agent communication mcp fix wait message

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,12 +1,11 @@
-name: Release
+name: NPM Publish
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 permissions:
-  contents: write
+  contents: read
   packages: write
 
 jobs:
@@ -14,13 +13,15 @@ jobs:
     name: Run All Tests
     uses: ./.github/workflows/ci.yml
 
-  release:
-    name: Create Release
+  publish:
+    name: Publish to NPM
     runs-on: ubuntu-latest
     needs: [test]
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        ref: ${{ github.event.release.tag_name }}
     
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -35,22 +36,8 @@ jobs:
     - name: Build project
       run: npm run build
     
-    - name: Create tarball
-      run: |
-        npm pack
-        mv *.tgz agent-communication-mcp.tgz
-    
-    - name: Create Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: |
-          agent-communication-mcp.tgz
-        generate_release_notes: true
-        draft: false
-        prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}
-    
     - name: Publish to npm
-      if: ${{ !contains(github.ref, '-beta') && !contains(github.ref, '-alpha') }}
+      if: ${{ !github.event.release.prerelease }}
       run: npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,6 @@ jobs:
       with:
         files: |
           agent-communication-mcp.tgz
-          dist/**/*
         generate_release_notes: true
         draft: false
         prerelease: ${{ contains(github.ref, '-beta') || contains(github.ref, '-alpha') }}

--- a/guide
+++ b/guide
@@ -1,0 +1,1 @@
+/home/miyagi/dev/tmp/tmp/claude_code_setup

--- a/test-data-message-service/rooms/general/messages.jsonl
+++ b/test-data-message-service/rooms/general/messages.jsonl
@@ -1,0 +1,2 @@
+{"id":"e04eaa41-216d-4cac-85ac-bdadbeab594b","agentName":"alice","message":"First message","timestamp":"2025-06-29T06:20:48.191Z","mentions":[]}
+{"id":"c095ad57-5352-44fb-99d5-61a80b7a861e","agentName":"bob","message":"Second message","timestamp":"2025-06-29T06:20:48.192Z","mentions":[]}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actionsワークフローが「Release」から「NPM Publish」に名称変更され、リリース公開時に実行されるようになりました。
  * リポジトリの権限設定やジョブの依存関係、チェックアウトの挙動が調整されました。
  * 一部不要なステップが削除され、npm publishの条件が明確化されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->