### PR TITLE
feat: increase message character limit from 1000 to 2000

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-communication-mcp",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "MCP server enabling room-based messaging between multiple agents",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/features/messaging/MessageValidator.ts
+++ b/src/features/messaging/MessageValidator.ts
@@ -6,7 +6,7 @@ import { WAIT_CONSTANTS } from './constants';
 export const sendMessageSchema = z.object({
   agentName: z.string().min(1).max(50),
   roomName: z.string().min(1).regex(/^[a-zA-Z0-9-_]+$/),
-  message: z.string().min(1).max(1000),
+  message: z.string().min(1).max(2000),
   metadata: z.record(z.any()).optional()
 });
 

--- a/src/schemas/message.schema.ts
+++ b/src/schemas/message.schema.ts
@@ -18,7 +18,7 @@ const agentNameSchema = z
 const messageContentSchema = z
   .string()
   .min(1, 'Message cannot be empty')
-  .max(1000, 'Message cannot exceed 1000 characters');
+  .max(2000, 'Message cannot exceed 2000 characters');
 
 // send_message ツール（実装済み）
 export const sendMessageInputSchema = z.object({

--- a/tests/messaging/integration/messaging-flow.test.ts
+++ b/tests/messaging/integration/messaging-flow.test.ts
@@ -254,7 +254,7 @@ describe('Messaging Integration Tests', () => {
       await expect(messagingAPI.sendMessage({
         agentName: 'alice',
         roomName: 'integration-test',
-        message: 'x'.repeat(1001)
+        message: 'x'.repeat(2001)
       })).rejects.toThrow();
     });
   });

--- a/tests/messaging/unit/MessageValidator.test.ts
+++ b/tests/messaging/unit/MessageValidator.test.ts
@@ -71,7 +71,7 @@ describe('MessageValidator', () => {
       const invalidParams = {
         agentName: 'test-agent',
         roomName: 'test-room',
-        message: 'a'.repeat(1001)
+        message: 'a'.repeat(2001)
       };
 
       expect(() => MessageValidator.validateSendMessage(invalidParams)).toThrow(ValidationError);

--- a/tests/messaging/unit/WaitForMessages.test.ts
+++ b/tests/messaging/unit/WaitForMessages.test.ts
@@ -749,8 +749,8 @@ describe('WaitForMessages', () => {
     });
 
     it('should handle very long message content', async () => {
-      // Message validator has a 1000 character limit
-      const longMessage = 'x'.repeat(1000);
+      // Message validator has a 2000 character limit
+      const longMessage = 'x'.repeat(2000);
       
       await messageService.sendMessage({
         agentName: 'bob',

--- a/tests/validation/schema-validation.test.ts
+++ b/tests/validation/schema-validation.test.ts
@@ -124,7 +124,7 @@ describe('Schema Validation Tests', () => {
         {
           agentName: 'alice',
           roomName: 'test-room',
-          message: 'x'.repeat(1001), // too long
+          message: 'x'.repeat(2001), // too long
         },
         {
           agentName: '', // empty agent name


### PR DESCRIPTION
## Summary
- Increased message character limit from 1000 to 2000 characters
- Updated validation schemas and tests accordingly
- Enables longer messages for code sharing and structured data exchange

## Changes
- Updated `messageContentSchema` in `src/schemas/message.schema.ts`
- Updated `sendMessageSchema` in `src/features/messaging/MessageValidator.ts`
- Updated related tests to validate the new 2000 character limit

## Test plan
- [x] Unit tests pass for MessageValidator
- [x] Integration tests pass for messaging flow
- [x] WaitForMessages tests updated and passing
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * メッセージの最大文字数が1000文字から2000文字に拡大され、より長いメッセージの送信が可能になりました。

* **テスト**
  * メッセージ長に関するテストケースを新しい上限（2000文字）に合わせて更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->